### PR TITLE
Resolved Logic Problems in Test-TargetResource

### DIFF
--- a/DscResources/MSFT_xSmbShare/MSFT_xSmbShare.psm1
+++ b/DscResources/MSFT_xSmbShare/MSFT_xSmbShare.psm1
@@ -315,27 +315,29 @@ function Test-TargetResource
         $Ensure
     )
     $testResult = $false;
-    $share = Get-SmbShare -Name $Name -ErrorAction SilentlyContinue -ErrorVariable ev
-    if ($Ensure -eq "Present")
+    $share = Get-TargetResource -Name $Name -Path $Path -ErrorAction SilentlyContinue -ErrorVariable ev
+    if ($Ensure -ne "Absent")
     {
-        if ($share -eq $null)
+        if ($share.Ensure -eq "Absent")
         {
             $testResult = $false
         }
-        elseif ($share -ne $null -and $PSBoundParameters.Count -gt 3)
-        # This means some other parameter in addition to Name, Path, Ensure could have been specified
-        # Which means we need to modify something
+        elseif ($share.Ensure -eq "Present")
         {
-            $testResult = $false
-        }
-        else
-        {
-            $testResult = $true
+            $Params = 'Name', 'Path', 'Description', 'ChangeAccess', 'ConcurrentUserLimit', 'EncryptData', 'FolderEnumerationMode', 'FullAccess', 'NoAccess', 'ReadAccess', 'Ensure'
+            if ($PSBoundParameters.Keys.Where({$_ -in $Params}) | ForEach-Object {Compare-Object -ReferenceObject $PSBoundParameters.$_ -DifferenceObject $share.$_})
+            { 
+                $testResult = $false
+            }
+            else
+            {
+                $testResult = $true
+            }
         }
     }
     else
     {
-        if ($share -eq $null)
+        if ($share.Ensure -eq "Absent")
         {
             $testResult = $true
         }


### PR DESCRIPTION
Test-TargetResource previously had a logic problem when more than three
parameters were specified would cause it to return a false negative.
This was a common occurrence considering that function has 11
parameters. The new logic makes ensure present the default if not
specified. It also compares only the specified parameters and returns
true if they match. It now calls Get-TargetResource and compares the
results to the input parameters to determine if the share is in the
desired state.